### PR TITLE
Speedup `get_variables_for_station`

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -107,9 +107,10 @@ def get_data(station_wsi: str, variable: str) -> list[tuple[datetime, float | No
 def get_variables_for_station(station_id: str):
     vars = get_variables()
     vars_with_data = []
+    ds_station = ds.sel(station=wsi_station_id_mapping[station_id]).load()
     for var in vars:
-        var_data = ds.sel(station=wsi_station_id_mapping[station_id])[var.id]
-        if not np.isnan(var_data.values).all():
+        var_data = ds_station[var.id]
+        if not np.any(~np.isnan(var_data.values)):
             vars_with_data.append(var)
     return vars_with_data
 


### PR DESCRIPTION
Small tweak to `get_variables_for_station` to speedup this function.

## What do we change
1. load all the data from a station in memory once (otherwise you load each variable one by one when calling `.values`). Calling `.values` on a slice of the original dataset is quite slow.
3. use `np.any` instead of `np.all` to allow for early breaks,

## Performance increase
Calling this function for each station (70) takes 48s in my laptop, after the change it takes about 4.4s,